### PR TITLE
Pin qiskit-terra version to 0.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pbr>=5.7.0
-qiskit-terra>=0.24.0
+qiskit-terra==0.24.0


### PR DESCRIPTION
Pin the qiskit-terra version to 0.24 since BaseScheduler in qiskit-terra changed an interface of a protected method in 0.25 and it broke CompactScheduleAnalysis.